### PR TITLE
Add more run-stage tasks, provide site info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This tool is intended for use by developers of the NHP model and not for wider p
 For now, the tool lets you review and update a model run's:
 
 * run-stage property (`run_stage`), which flags scenarios for use by [nhp_output_reports](https://github.com/The-Strategy-Unit/nhp_output_reports) and other secondary products
-* site properties (`sites_ip`, `sites_op` and`sites_aae`), which are used to filter results in [nhp_output_reports](https://github.com/The-Strategy-Unit/nhp_output_reports) (in development)
+* site properties (`sites_ip`, `sites_op` and `sites_aae`), which are used to filter results in [nhp_output_reports](https://github.com/The-Strategy-Unit/nhp_output_reports)
 
 ## Usage
 
@@ -31,6 +31,12 @@ After cloning the repo, set two values in a `.env` file in the project directory
 They're used to build the table endpoint in the form `https://demoaccount.table.core.windows.net/demotable`.
 
 Authorised users can obtain these values from the Data Science team.
+
+Then you can develop the tool with the project in editable mode:
+
+```bash
+uv pip install -e .
+```
 
 ### To install
 

--- a/src/nhp_ats_tui/__init__.py
+++ b/src/nhp_ats_tui/__init__.py
@@ -1,5 +1,6 @@
 from .table import (
     get_table_client,
+    get_table_entity,
     get_unique_schemes,
     fetch_scenarios,
     list_scenarios,
@@ -9,6 +10,7 @@ from .table import (
 
 __all__ = [
     "get_table_client",
+    "get_table_entity",
     "get_unique_schemes",
     "fetch_scenarios",
     "list_scenarios",

--- a/src/nhp_ats_tui/table.py
+++ b/src/nhp_ats_tui/table.py
@@ -146,7 +146,7 @@ def update_run_stage(
     tag_choice: str,
 ) -> None:
     """
-    Update the run-stage tag for an existing scenario entity.
+    Update the run-stage property for an existing scenario entity.
 
     Args:
         table_client (TableClient): An authenticated TableClient.
@@ -171,39 +171,38 @@ def update_sites(
     scheme_choice: str,
     scenario_choice: str,
     activity_type_choice: str,
-    sites_provided: str,
+    sites_provided: str | None,
 ) -> None:
     """
-    Update the site codes for an existing scenario entity.
+    Update or remove the site-code property for an existing scenario entity.
 
     Args:
         table_client (TableClient): An authenticated TableClient.
         scheme_choice (str): Selected scheme code (the entity's PartitionKey).
         scenario_choice (str): Selected scenario name.
         activity_type_choice (str): Selected activity type.
-        sites_provided (str): A comma-separated string of site codes.
+        sites_provided (str | None): A comma-separated string of site codes.
 
     Returns:
         None. The entity is updated the corresponding Azure Table Storage.
     """
     entity = get_table_entity(table_client, scheme_choice, scenario_choice)
 
-    sites_provided = sites_provided or ""
-
     if "inpatients" in activity_type_choice:
-        if sites_provided == "":  # blank user input means remove property
-            entity.pop("sites_ip", None)  # to remove property
+        # Remove the property from the entity if empty, otherwise overwrite
+        if sites_provided is None:
+            entity.pop("sites_ip", None)
         else:
             entity["sites_ip"] = sites_provided
 
     if "outpatients" in activity_type_choice:
-        if sites_provided == "":
+        if sites_provided is None:
             entity.pop("sites_op", None)
         else:
             entity["sites_op"] = sites_provided
 
     if "A&E" in activity_type_choice:
-        if sites_provided == "":
+        if sites_provided is None:
             entity.pop("sites_aae", None)
         else:
             entity["sites_aae"] = sites_provided

--- a/src/nhp_ats_tui/table.py
+++ b/src/nhp_ats_tui/table.py
@@ -2,7 +2,7 @@
 Access and handle entities from Azure Table Storage.
 """
 
-from azure.data.tables import TableClient, UpdateMode
+from azure.data.tables import TableClient, TableEntity, UpdateMode
 from azure.identity import DefaultAzureCredential
 
 
@@ -27,6 +27,38 @@ def get_table_client(storage_account_name: str, table_name: str) -> TableClient:
     )
 
     return table_client
+
+
+def get_table_entity(
+    table: TableClient,
+    scheme_choice: str,
+    scenario_choice: str,
+) -> TableEntity:
+    """
+    Get a TableEntity from an authenticated TableClient instance.
+
+    Args:
+        table (TableClient): An authenticated TableClient.
+        scheme_choice (str): Selected scheme code (the entity's PartitionKey).
+        scenario_choice (str): Selected scenario name.
+
+    Returns:
+        A TableEntity.
+    """
+
+    scenario_choice_split = scenario_choice.split()
+    scenario = scenario_choice_split[0]
+    created = scenario_choice_split[1].strip("()")
+
+    # RowKey is an entity-unique identifier, composed of name and datetime
+    row_key = f"{scenario}-{created}"
+
+    entity = table.get_entity(
+        partition_key=scheme_choice,
+        row_key=row_key,
+    )
+
+    return entity
 
 
 def get_unique_schemes(table: TableClient) -> list[str]:
@@ -54,7 +86,7 @@ def fetch_scenarios(table: TableClient, scheme_code: str) -> list[dict]:
 
     Args:
         table (TableClient): An authenticated TableClient.
-        scheme_code (str): Selected scheme code (the table's PartitionKey).
+        scheme_code (str): Selected scheme code (the entity's PartitionKey).
 
     Returns:
         A list of dictionaries containing scenario metadata.
@@ -91,7 +123,7 @@ def list_scenarios(scenarios: list[dict]) -> list[str]:
 
     Returns:
         A list of formatted scenario labels for TUI selection, in the format
-        "<scenario> (<create_datetime>) [<run_stage>]".
+        "<scenario> (<create_datetime>)", possibly appended with "[<run_stage>]".
     """
     values = []
     for scenario in scenarios:
@@ -114,29 +146,18 @@ def update_run_stage(
     tag_choice: str,
 ) -> None:
     """
-    Update the run_stage tag for an existing scenario entity.
+    Update the run-stage tag for an existing scenario entity.
 
     Args:
         table_client (TableClient): An authenticated TableClient.
-        scheme_choice (str): Selected scheme code (the table's PartitionKey).
-        scenario_choice (str): Selected scenario label.
+        scheme_choice (str): Selected scheme code (the entity's PartitionKey).
+        scenario_choice (str): Selected scenario name.
         tag_choice (str): Selected run-stage tag.
 
     Returns:
         None. The entity is updated the corresponding Azure Table Storage.
     """
-    scenario_choice_split = scenario_choice.split()
-    scenario = scenario_choice_split[0]
-    created = scenario_choice_split[1].strip("()")
-
-    # RowKey is an entity-unique identifier, composed of name and datetime
-    row_key = f"{scenario}-{created}"
-
-    entity = table_client.get_entity(
-        partition_key=scheme_choice,
-        row_key=row_key,
-    )
-
+    entity = get_table_entity(table_client, scheme_choice, scenario_choice)
     entity["run_stage"] = tag_choice
 
     table_client.update_entity(
@@ -157,26 +178,15 @@ def update_sites(
 
     Args:
         table_client (TableClient): An authenticated TableClient.
-        scheme_choice (str): Selected scheme code (the table's PartitionKey).
-        scenario_choice (str): Selected scenario label.
+        scheme_choice (str): Selected scheme code (the entity's PartitionKey).
+        scenario_choice (str): Selected scenario name.
         activity_type_choice (str): Selected activity type.
         sites_provided (str): A comma-separated string of site codes.
 
     Returns:
         None. The entity is updated the corresponding Azure Table Storage.
     """
-    scenario_choice_split = scenario_choice.split()
-    scenario = scenario_choice_split[0]
-    created = scenario_choice_split[1].strip("()")
-
-    # RowKey is an entity-unique identifier, composed of name and datetime
-    row_key = f"{scenario}-{created}"
-
-    # Retrieve all properties for the given entity
-    entity = table_client.get_entity(
-        partition_key=scheme_choice,
-        row_key=row_key,
-    )
+    entity = get_table_entity(table_client, scheme_choice, scenario_choice)
 
     sites_provided = sites_provided or ""
 
@@ -199,6 +209,6 @@ def update_sites(
             entity["sites_aae"] = sites_provided
 
     table_client.update_entity(
-        entity=entity,  # all properties except popped
-        mode=UpdateMode.REPLACE,  # we can REPLACE because entity has all properties
+        entity=entity,  # all properties except removed ('popped') ones
+        mode=UpdateMode.REPLACE,  # REPLACE because entity has all properties
     )

--- a/src/nhp_ats_tui/table.py
+++ b/src/nhp_ats_tui/table.py
@@ -143,7 +143,7 @@ def update_run_stage(
     table_client: TableClient,
     scheme_choice: str,
     scenario_choice: str,
-    tag_choice: str,
+    tag_choice: str | None,
 ) -> None:
     """
     Update the run-stage property for an existing scenario entity.
@@ -152,17 +152,21 @@ def update_run_stage(
         table_client (TableClient): An authenticated TableClient.
         scheme_choice (str): Selected scheme code (the entity's PartitionKey).
         scenario_choice (str): Selected scenario name.
-        tag_choice (str): Selected run-stage tag.
+        tag_choice (str | None): Selected run-stage tag.
 
     Returns:
         None. The entity is updated the corresponding Azure Table Storage.
     """
     entity = get_table_entity(table_client, scheme_choice, scenario_choice)
-    entity["run_stage"] = tag_choice
+
+    if tag_choice is None:
+        entity.pop("run_stage", None)
+    else:
+        entity["run_stage"] = tag_choice
 
     table_client.update_entity(
         entity=entity,
-        mode=UpdateMode.MERGE,  # update existing entity
+        mode=UpdateMode.REPLACE,  # REPLACE because properties may have been removed
     )
 
 
@@ -208,6 +212,6 @@ def update_sites(
             entity["sites_aae"] = sites_provided
 
     table_client.update_entity(
-        entity=entity,  # all properties except removed ('popped') ones
-        mode=UpdateMode.REPLACE,  # REPLACE because entity has all properties
+        entity=entity,
+        mode=UpdateMode.REPLACE,  # REPLACE because properties may have been removed
     )

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -79,29 +79,26 @@ def main() -> None:
 
         if "inpatients" in task_choice:
             activity_type_choice = "inpatients"
-            sites_existing = entity.get("sites_ip")
+            sites_existing = entity.get("sites_ip") or "none"
         elif "outpatients" in task_choice:
             activity_type_choice = "outpatients"
-            sites_existing = entity.get("sites_op")
+            sites_existing = entity.get("sites_op") or "none"
         elif "A&E" in task_choice:
             activity_type_choice = "A&E"
-            sites_existing = entity.get("sites_aae")
+            sites_existing = entity.get("sites_aae") or "none"
 
         print(f"ℹ️  Current {activity_type_choice} sites: {sites_existing}")
 
-        sites_provided = (
-            inquirer.text(
-                "Provide sites (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
-            ).execute()
-            or ""
-        )
+        sites_provided = inquirer.text(
+            "Provide sites (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
+        ).execute()
 
         update_sites(
             table,
             scheme_choice,
             scenario_choice,
             activity_type_choice,
-            sites_provided,  # gets deleted if empty string
+            sites_provided,  # site property deleted if None
         )
 
         if sites_provided == "":

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -28,7 +28,7 @@ def main() -> None:
     if not storage_account_name or not table_name:
         raise EnvironmentError(
             "AZURE_STORAGE_ACCOUNT_NAME and MODEL_RUNS_TABLE_NAME must be set."
-    )
+        )
 
     print("⏳ Connecting to table...")
     table = get_table_client(storage_account_name, table_name)

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 
 from .table import (
     get_table_client,
+    get_table_entity,
     get_unique_schemes,
     fetch_scenarios,
     list_scenarios,
@@ -71,21 +72,26 @@ def main() -> None:
 
         update_run_stage(table, scheme_choice, scenario_choice, tag_choice)
 
-        print(f"🏷️  Set run_stage tag to '{tag_choice}'.")
+        print(f"✅ Set run_stage tag to '{tag_choice}'. Exiting.")
 
     elif "Edit sites" in task_choice:
-        print("Current sites: TODO")
+        entity = get_table_entity(table, scheme_choice, scenario_choice)
 
         if "inpatients" in task_choice:
             activity_type_choice = "inpatients"
+            sites_existing = entity.get("sites_ip")
         elif "outpatients" in task_choice:
             activity_type_choice = "outpatients"
+            sites_existing = entity.get("sites_op")
         elif "A&E" in task_choice:
             activity_type_choice = "A&E"
+            sites_existing = entity.get("sites_aae")
+
+        print(f"ℹ️  Current {activity_type_choice} sites: {sites_existing}")
 
         sites_provided = (
             inquirer.text(
-                "Provide sites (like 'XYZ01,XYZ02' or 'ALL' or blank to remove):"
+                "Provide sites (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
             ).execute()
             or ""
         )
@@ -99,11 +105,11 @@ def main() -> None:
         )
 
         if sites_provided == "":
-            print(f"🏥 Removed all {activity_type_choice} sites.")
+            print(f"✅ Removed all {activity_type_choice} sites. Exiting.")
         else:
-            print(f"🏥 Set {activity_type_choice} sites to '{sites_provided}'.")
-
-    print(f"✅ Updated {scenario_choice} for scheme {scheme_choice}. Exiting.")
+            print(
+                f"✅ Set {activity_type_choice} sites to '{sites_provided}'. Exiting."
+            )
 
 
 if __name__ == "__main__":

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -60,19 +60,37 @@ def main() -> None:
     ).execute()
 
     if task_choice == "Edit the run stage":
-        tag_choice = inquirer.select(
-            message="Choose a run-stage tag:",
-            choices=[
-                "final_report_ndg2",
-                "final_report_ndg3",
-                "validation_report_ndg2",
-                "validation_report_ndg3",
-            ],
+        tag_subtask_choice = inquirer.select(
+            message="Choose a run-stage option:",
+            choices=["Add/change", "Remove"],
         ).execute()
+
+        if tag_subtask_choice == "Remove":
+            tag_choice = None  # will remove the run_stage property from the entity
+
+        if tag_subtask_choice == "Add/change":
+            tag_choice = inquirer.select(
+                message="Choose a run-stage tag:",
+                choices=[
+                    "final_report_ndg2",
+                    "final_report_ndg3",
+                    "validation_report_ndg3",
+                    "validation_report_ndg2",
+                    "Other"
+                ],
+            ).execute()
+
+            if tag_choice == "Other":
+                tag_choice = inquirer.text(
+                    "Type a run-stage tag (lowercase, underscore-separated, with NDG variant):"
+                ).execute()
 
         update_run_stage(table, scheme_choice, scenario_choice, tag_choice)
 
-        print(f"✅ Set run_stage tag to '{tag_choice}'. Exiting.")
+        if tag_subtask_choice == "Remove":
+            print("✅ Removed run-stage tag. Exiting.")
+        else:
+            print(f"✅ Set run-stage tag to '{tag_choice}'. Exiting.")
 
     elif "Edit sites" in task_choice:
         entity = get_table_entity(table, scheme_choice, scenario_choice)
@@ -90,7 +108,7 @@ def main() -> None:
         print(f"ℹ️  Current {activity_type_choice} sites: {sites_existing}")
 
         sites_provided = inquirer.text(
-            "Provide sites (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
+            "Type site codes (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
         ).execute()
 
         update_sites(

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -50,7 +50,7 @@ def main() -> None:
     ).execute()
 
     task_choice = inquirer.select(
-        message="Choose a task",
+        message="Choose a task:",
         choices=[
             "Edit the run stage",
             "Edit sites (inpatients)",


### PR DESCRIPTION
Close #9. Close #10.

## Changes

User facing:

* Added steps to let user (a) choose to add/change or remove a run-stage, and (b) allow a free-text custom tag.
* Reminded the user of the current site codes for the activity type they've selected.

Back-end:

* Preferred to handle `None` throughout, rather than via conversion to an empty string.
* Improved DRYness with the introduction of a `get_table_entity()` function.
* Improved some docstrings/inline comments.

## Examples

Example of the new hierarchy of steps in the run-stage journey:

```
? Choose a task:
❯ Edit the run stage
  Edit sites (inpatients)
  Edit sites (outpatients)
  Edit sites (A&E)
```

```
? Choose a run-stage option:
❯ Add/change
  Remove
```

```
? Choose a run-stage tag:
  final_report_ndg2
  final_report_ndg3
  validation_report_ndg3
  validation_report_ndg2
❯ Other
```

```
? Type a run-stage tag (lowercase, underscore-separated, with NDG variant): test_tag_ndgx
✅ Set run-stage tag to 'test_tag_ndgx'. Exiting.
```

Example that we now show current sites when user tries to edit them:

```
? Choose a task:
  Edit the run stage
❯ Edit sites (inpatients)
  Edit sites (outpatients)
  Edit sites (A&E)
```

```
ℹ️  Current inpatients sites: none
? Type site codes (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove: XYZ05,XYZ10
✅ Set inpatients sites to 'XYZ05,XYZ10'. Exiting.
```

Happy to talk about any of this, of course.