### PR TITLE
Bump v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nhp_ats_tui"
-version = "0.1.0.9000"
+version = "0.3.0"
 description = "TUI to edit NHP model-run entities in Azure Table Storage"
 authors = [
     { name = "Matt Dray", email = "matt.dray@nhs.net" },

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -119,9 +119,12 @@ def main() -> None:
                 )
                 print(f"ℹ Current {activity_type_choice} sites: {sites_existing}.")
 
-                sites_provided = inquirer.text(
-                    "Type site codes (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
-                ).execute()
+                sites_provided = (
+                    inquirer.text(
+                        "Type site codes (e.g. 'XYZ01,XYZ02', 'ALL') or leave blank to remove:"
+                    ).execute()
+                    or None
+                )
 
                 update_sites(
                     table,
@@ -130,7 +133,7 @@ def main() -> None:
                     sites_provided,  # site property will be deleted if None
                 )
 
-                if sites_provided == "":
+                if sites_provided is None:
                     print(f"✓ Removed all {activity_type_choice} sites.")
                     print("ℹ Returning to scheme selection. Use Ctrl+C to exit.")
                 else:

--- a/src/nhp_ats_tui/tui.py
+++ b/src/nhp_ats_tui/tui.py
@@ -59,7 +59,7 @@ def main() -> None:
             dataset_entities = filter_entities_by_dataset(entities, scheme_choice)
             scenarios_lookup = create_scenario_label_lookup(dataset_entities)
 
-            scenario_choice = inquirer.select(
+            scenario_choice = inquirer.fuzzy(
                 message="Choose a scenario to edit:",
                 choices=list(scenarios_lookup.keys()),
             ).execute()

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "nhp-ats-tui"
-version = "0.1.0.9000"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-data-tables" },


### PR DESCRIPTION
Little updates to prep for release. I:

* bumped to version v0.3.0
* used fuzzy select to more easily search for scenarios
* preferred `None` to `""` when user wants sites removed (guarantees property deletion for that entity)

I've used this successfully on the demo ATS table and also [to tag R0A](https://github.com/The-Strategy-Unit/nhp_planning/issues/636) in the main table.

Will release v0.3.0 once merged.